### PR TITLE
One extra HMAC is required in bad rs computation

### DIFF
--- a/lib/ecdsa.js
+++ b/lib/ecdsa.js
@@ -119,6 +119,8 @@ ECDSA.prototype.deterministicK = function(badrs) {
   // also explained in 3.2, we must ensure T is in the proper range (0, N)
   for (var i = 0; i < badrs || !(T.lt(N) && T.gt(0)); i++) {
     k = Hash.sha256hmac(Buffer.concat([v, new Buffer([0x00])]), k);
+    if (i > 0)
+      v = Hash.sha256hmac(v, k);
     v = Hash.sha256hmac(v, k);
     T = BN().fromBuffer(v);
   }


### PR DESCRIPTION
A bug reporter has reported that this same logic in bitcore has a problem, see
here:

https://github.com/bitpay/bitcore/pull/884

A re-reading of RFC 6969 indicates that an extra HMAC computation is performed
when badrs > 0. This fixes this possible error, but not extra test cases are
included, because I'm not aware of a test case when badrs > 0.